### PR TITLE
[CSS] Improve Word Wrap in Parameter tables

### DIFF
--- a/docs/_static/extra.css
+++ b/docs/_static/extra.css
@@ -1,1 +1,13 @@
-:root {}
+:root {
+
+    /*
+    * Only wrap the last column of a table
+    */
+    table {
+        white-space: nowrap;
+
+        td:nth-last-child(1) {
+            white-space: normal;
+        }
+    }
+}


### PR DESCRIPTION
This is a CSS-only change to how wrapping is handled for tables. Prior to this change, many parameter tables were wrapping the first and second columns poorly, with single characters broken out to their own lines.

Rather than explicitly disable wrapping for the first and second columns—which would break some of the 2-column tables—this PR disables wrapping for all columns and then uses on override to enable wrapping for the last column using `nth-last-child`. The last column of all tables contains the description, which is the most verbose and most likely to require wrapping.

Found `nth-last-child` strategy via https://css-tricks.com/how-nth-child-works/

### Testing:
Reviewed tables to ensure the wrapping remained consistent and correct.