### PR TITLE
Adds 'print' workflow for offline use

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -134,3 +134,4 @@ plugins:
         add_print_site_banner: true
         cover_page_template: "overrides/templates/print_site_cover_page.tpl"
         print_page_title: "Printable Docs"
+        print_site_banner_template: "overrides/templates/print_site_banner.tpl"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -81,6 +81,7 @@ nav:
             - Layer Styles Match Names: matchnames/layer/layerstyles.md
         - Effects:
             - First-Party Effect Match Names: matchnames/effects/firstparty.md
+    - Printable Docs: /print_page
 
 
 # Do not touch below-- shared for all docs
@@ -127,3 +128,4 @@ plugins:
     - git-revision-date-localized
     - search:
         separator: '[\s\-,\.:!=\[\]()"/]+'
+    - print-site

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -128,4 +128,7 @@ plugins:
     - git-revision-date-localized
     - search:
         separator: '[\s\-,\.:!=\[\]()"/]+'
-    - print-site
+    - print-site:
+        print_page_title: "Printable Docs"
+        add_cover_page: true
+        add_print_site_banner: true

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -82,7 +82,6 @@ nav:
             - Layer Styles Match Names: matchnames/layer/layerstyles.md
         - Effects:
             - First-Party Effect Match Names: matchnames/effects/firstparty.md
-    - Printable Docs: /print_page
 
 
 # Do not touch below-- shared for all docs

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -132,5 +132,5 @@ plugins:
         add_cover_page: true
         add_print_site_banner: true
         cover_page_template: "overrides/templates/print_site_cover_page.tpl"
-        print_page_title: "Printable Docs"
+        print_page_title: "Offline Docs"
         print_site_banner_template: "overrides/templates/print_site_banner.tpl"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,6 +5,7 @@ repo_url: https://github.com/docsforadobe/after-effects-scripting-guide/
 repo_name: "after-effects-scripting-guide"
 extra:
     homepage: https://docsforadobe.dev
+copyright: All content is copyright Adobe Systems Incorporated.
 
 # Customize navigation
 nav:
@@ -129,6 +130,7 @@ plugins:
     - search:
         separator: '[\s\-,\.:!=\[\]()"/]+'
     - print-site:
-        print_page_title: "Printable Docs"
         add_cover_page: true
         add_print_site_banner: true
+        cover_page_template: "overrides/templates/print_site_cover_page.tpl"
+        print_page_title: "Printable Docs"

--- a/overrides/partials/copyright.html
+++ b/overrides/partials/copyright.html
@@ -1,0 +1,25 @@
+<div class="md-copyright">
+  {% if config.copyright %}
+    <div class="md-copyright__highlight">
+      {{ config.copyright }}
+    </div>
+  {% endif %}
+  {% if not config.extra.generator == false %}
+    Made with
+    <a
+      href="https://squidfunk.github.io/mkdocs-material/"
+      target="_blank" rel="noopener"
+    >
+      Material for MkDocs
+    </a>
+  {% endif %}
+</div>
+
+<!-- Print button -->
+<div class="md-copyright">
+  {% if page.url_to_print_page %}
+  <a href="{{ page.url_to_print_page }}" title="Print Site" class="md-content__button md-icon">
+      {% include ".icons/material/printer.svg" %}
+  </a>
+  {% endif %}
+</div>

--- a/overrides/templates/print_site_banner.tpl
+++ b/overrides/templates/print_site_banner.tpl
@@ -1,11 +1,21 @@
-<p>
-    <em>This box will disappear when printing!</em>
-</p>
+<style>
+    #print-site-banner {
+        border: 0px;
+    }
+</style>
 
-<p>
-    This page has combined all site pages into one. You can export to PDF using <b>File > Print > Save as PDF</b>.
-</p>
+<div class="admonition info">
 
-<p>
-    Note that users may have issues <a href="https://github.com/timvink/mkdocs-print-site-plugin/issues/56">printing to PDF on Firefox</a>.
-</p>
+    <p class="admonition-title">Note – This box will disappear during export!</p>
+
+    <p>This page has combined all site pages into one, and can be exported using native browser features.</p>
+
+    <p>You can export to PDF using <b>File > Print > Save as PDF</b>, or save as a single-page HTML file via <b>File > Save As</b>.</p>
+
+    <div class="admonition warning">
+        <p class="admonition-title">Warning</p>
+
+        <p>Note that users may have issues <a href="https://github.com/timvink/mkdocs-print-site-plugin/issues/56">printing to PDF on Firefox</a>.</p>
+    </div>
+
+</div>

--- a/overrides/templates/print_site_banner.tpl
+++ b/overrides/templates/print_site_banner.tpl
@@ -1,0 +1,11 @@
+<p>
+    <em>This box will disappear when printing!</em>
+</p>
+
+<p>
+    This page has combined all site pages into one. You can export to PDF using <b>File > Print > Save as PDF</b>.
+</p>
+
+<p>
+    Note that users may have issues <a href="https://github.com/timvink/mkdocs-print-site-plugin/issues/56">printing to PDF on Firefox</a>.
+</p>

--- a/overrides/templates/print_site_cover_page.tpl
+++ b/overrides/templates/print_site_cover_page.tpl
@@ -1,0 +1,44 @@
+<div>
+
+    {% if config.site_name %}
+        <h1>{{ config.site_name }}</h1>
+    {% endif %}
+
+    {% if config.extra.homepage %}
+        by <h3><a href="{{ config.extra.homepage }}">{{ config.extra.homepage }}</a></h3>
+    {% endif %}
+
+</div>
+
+
+<table>
+
+    {% if config.site_description %}
+    <tr>
+        <td>Description</td>
+        <td>{{ config.site_description }}</td>
+    </tr>
+    {% endif %}
+
+    {% if config.site_url %}
+    <tr>
+        <td>Hosted at</td>
+        <td>{{ config.site_url }}</td>
+    </tr>
+    {% endif %}
+
+    {% if config.repo_url %}
+    <tr>
+        <td>Repository</td>
+        <td><a href="{{ config.repo_url }}">{{ config.repo_url }}</a></td>
+    </tr>
+    {% endif %}
+
+    {% if config.copyright %}
+    <tr>
+        <td>Copyright</td>
+        <td>{{ config.copyright }}</td>
+    </tr>
+    {% endif %}
+
+</table>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 mkdocs
 mkdocs-material
 mkdocs-git-revision-date-localized-plugin
+mkdocs-print-site-plugin


### PR DESCRIPTION
- This adds a 'print' button to the bottom copyright footer
- Clicking it will take the user to a single, large page that contains _all_ of the docs
- This page can then be "printed" to pdf (or saved as html) from the viewer's browser for offline use