### PR TITLE
Update .lightSource attribute of Light Layer with New Beta Functionality

### DIFF
--- a/docs/introduction/changelog.md
+++ b/docs/introduction/changelog.md
@@ -10,6 +10,11 @@ What's new and changed for scripting?
 
 ## After Effects 25
 
+### [After Effects 25.2 Beta build 98](https://community.adobe.com/t5/after-effects-beta-discussions/animated-environmental-lights-available-now-in-after-effects-beta/td-p/15130220) (February 2025)
+
+- Scripting methods and attributes added:
+    - Updated: [LightLayer.lightSource](../layer/lightlayer.md#lightlayerlightsource)
+
 ### [After Effects 25.0 Beta build 26](https://community.adobe.com/t5/after-effects-beta-discussions/new-in-ae-25-0-build-25-scripting-hooks-for-font-fallback-management/m-p/14809794) (August 2024)
 
 - Scripting methods and attributes added:

--- a/docs/layer/lightlayer.md
+++ b/docs/layer/lightlayer.md
@@ -41,13 +41,15 @@ LightLayer defines no additional attributes, but has different AE properties tha
 `app.project.item(index).layer(index).lightSource`
 
 !!! note
-    `LightLayer.lightSource` was added in After Effects 24.3
+    `LightLayer.lightSource` was added in After Effects 24.3, but allowed only HDR and EXR layers as sources.
+
+    In After Effects (Beta) 25.2.0.098, it was updated to allow any 2D layer type as a source.
 
 #### Description
 
 For a light layer, the layer to use as a light source when `LightLayer.lightType` is `LightType.ENVIRONMENT`.
 
-`LightLayer.layerSource` must be a footage layer referencing a .EXR or .HDR footage item. Trying to set this attribute to any other layer produces an error.
+`LightLayer.lightSource` can be any 2D video, still, or pre-composition layer in the same composition. Attempting to assign a 3D layer as the `.lightSource` will result in an "Invalid light source specified" error.
 
 ---
 


### PR DESCRIPTION
As announced [here](https://community.adobe.com/t5/after-effects-beta-discussions/animated-environmental-lights-available-now-in-after-effects-beta/td-p/15130220) in Beta, the `lightSource` attribute of `LightLayer` now accepts all 2D layers as input, rather than only those with HDR/EXR sources.

This updates both the API itself and the changelog with a link to the forum post for details.