### PR TITLE
Update scripting APIs for 25.4

### DIFF
--- a/docs/general/application.md
+++ b/docs/general/application.md
@@ -829,6 +829,24 @@ Nothing.
 
 ---
 
+### app.restart()
+
+`app.restart()`
+
+#### Description
+
+Restarts the After Effects application.
+
+#### Parameters
+
+None.
+
+#### Returns
+
+Nothing.
+
+---
+
 ### app.scheduleTask()
 
 `app.scheduleTask(stringToExecute, delay, repeat)`

--- a/docs/introduction/changelog.md
+++ b/docs/introduction/changelog.md
@@ -20,7 +20,7 @@ What's new and changed for scripting?
 - Scripting methods and attributes added:
     - Added: [CharacterRange.pasteFrom()](../text/characterrange.md#characterrangepastefrom)
     - Added: [FontObject.hasGlyphsFor()](../text/fontobject.md#fontobjecthasglyphsfor)
-    - Added: [FontObject.otherFontsWithSameDict()](../text/fontobject.md#fontobjectotherfontswithsamedict)
+    - Added: [FontObject.otherFontsWithSameDict](../text/fontobject.md#fontobjectotherfontswithsamedict)
     - Added: [FontsObject.getCTScriptForString()](../text/fontsobject.md#fontsobjectgetctscriptforstring)
     - Added: [FontsObject.getDefaultFontForCTScript()](../text/fontsobject.md#fontsobjectgetdefaultfontforctscript)
     - Added: [FontsObject.setDefaultFontForCTScript()](../text/fontsobject.md#fontsobjectsetdefaultfontforctscript)

--- a/docs/introduction/changelog.md
+++ b/docs/introduction/changelog.md
@@ -15,7 +15,7 @@ What's new and changed for scripting?
 - Scripting methods and attributes added:
     - Updated: [LightLayer.lightSource](../layer/lightlayer.md#lightlayerlightsource)
 
-### [After Effects 25.0 Beta build 26](https://community.adobe.com/t5/after-effects-beta-discussions/new-in-ae-25-0-build-25-scripting-hooks-for-font-fallback-management/m-p/14809794) (August 2024)
+### [After Effects 25.1](https://helpx.adobe.com/after-effects/using/whats-new/2025-1.html) (December 2024)
 
 - Scripting methods and attributes added:
     - Added: [CharacterRange.pasteFrom()](../text/characterrange.md#characterrangepastefrom)

--- a/docs/introduction/changelog.md
+++ b/docs/introduction/changelog.md
@@ -10,6 +10,10 @@ What's new and changed for scripting?
 
 ## After Effects 25
 
+### [After Effects 25.4](https://helpx.adobe.com/after-effects/using/whats-new/2025-4.html) (August 2025)
+
+- Scripting method added: [app.restart()](../general/application.md#apprestart)
+
 ### [After Effects 25.2](https://helpx.adobe.com/after-effects/using/whats-new/2025-2.html) (April 2025)
 
 - Scripting methods and attributes added:

--- a/docs/introduction/changelog.md
+++ b/docs/introduction/changelog.md
@@ -10,7 +10,7 @@ What's new and changed for scripting?
 
 ## After Effects 25
 
-### [After Effects 25.2 Beta build 98](https://community.adobe.com/t5/after-effects-beta-discussions/animated-environmental-lights-available-now-in-after-effects-beta/td-p/15130220) (February 2025)
+### [After Effects 25.2](https://helpx.adobe.com/after-effects/using/whats-new/2025-2.html) (April 2025)
 
 - Scripting methods and attributes added:
     - Updated: [LightLayer.lightSource](../layer/lightlayer.md#lightlayerlightsource)

--- a/docs/introduction/changelog.md
+++ b/docs/introduction/changelog.md
@@ -55,7 +55,7 @@ What's new and changed for scripting?
     - Added: [Project.replaceFont()](../general/project.md#projectreplacefont)
     - Added: [Project.usedFonts](../general/project.md#projectusedfonts)
 
-### [After Effects 24.4 Beta build 25](https://community.adobe.com/t5/after-effects-beta-discussions/scripting-new-api-for-3d-model-layers/td-p/14580044) (March 2024)
+### [After Effects 24.4](https://helpx.adobe.com/after-effects/using/whats-new/2024-4.html) (May 2024)
 
 - Added: [ThreeDModelLayer object](../layer/threedmodellayer.md)
 

--- a/docs/layer/lightlayer.md
+++ b/docs/layer/lightlayer.md
@@ -43,7 +43,7 @@ LightLayer defines no additional attributes, but has different AE properties tha
 !!! note
     `LightLayer.lightSource` was added in After Effects 24.3, but allowed only HDR and EXR layers as sources.
 
-    In After Effects (Beta) 25.2.0.098, it was updated to allow any 2D layer type as a source.
+    In After Effects 25.2, it was updated to allow any 2D layer type as a source.
 
 #### Description
 

--- a/docs/text/characterrange.md
+++ b/docs/text/characterrange.md
@@ -217,7 +217,7 @@ String; read/write.
 `CharacterRange.pasteFrom(characterRange)`
 
 !!! note
-    This functionality was added in After Effects (Beta) 25.0 and is subject to change while it remains in Beta.
+    This functionality was added in After Effects 25.1
 
 #### Description
 

--- a/docs/text/fontobject.md
+++ b/docs/text/fontobject.md
@@ -230,6 +230,25 @@ String; read-only.
 
 ---
 
+### FontObject.otherFontsWithSameDict
+
+`app.fonts.fontsWithDefaultDesignAxes[0].otherFontsWithSameDict`
+
+!!! note
+    This functionality was added in After Effects (Beta) 25.0 and is subject to change while it remains in Beta.
+
+#### Description
+
+Returns an Array of [Font object](#font-object) instances which share the same font dictionary as this [Font object](#font-object).
+
+Will return an empty Array if this [Font object](#font-object) is not a Variable font, or the Variable font only has one instance.
+
+#### Type
+
+Array of [Font objects](#font-object); read-only.
+
+---
+
 ### FontObject.postScriptName
 
 `app.fonts.allFonts[0][0].postScriptName`
@@ -475,30 +494,6 @@ Boolean.
 
 ---
 
-### FontObject.otherFontsWithSameDict()
-
-`app.fonts.fontsWithDefaultDesignAxes[0].otherFontsWithSameDict(fontObject)`
-
-!!! note
-    This functionality was added in After Effects (Beta) 25.0 and is subject to change while it remains in Beta.
-
-#### Description
-
-Given an [Font object](#font-object) passed as an argument, returns an Array of [Font object](#font-object) instances which share the same font dictionary as the [Font object](#font-object) the function is called on.
-
-Will return an empty Array if the argument is not a Variable font, or the Variable font only has one instance (the parameter one).
-
-#### Parameters
-
-|  Parameter   |            Type             |   Description   |
-| ------------ | --------------------------- | --------------- |
-| `fontObject` | [Font object](#font-object) | Object to check |
-
-#### Returns
-
-Array of [Font objects](#font-object), may be empty.
-
----
 
 ### FontObject.postScriptNameForDesignVector()
 

--- a/docs/text/fontobject.md
+++ b/docs/text/fontobject.md
@@ -235,7 +235,7 @@ String; read-only.
 `app.fonts.fontsWithDefaultDesignAxes[0].otherFontsWithSameDict`
 
 !!! note
-    This functionality was added in After Effects (Beta) 25.0 and is subject to change while it remains in Beta.
+    This functionality was added in After Effects 25.1
 
 #### Description
 
@@ -448,7 +448,7 @@ An array of `CTScript` enumerated values; read-only. One or more of:
 `app.fonts.allFonts[0][0].hasGlyphsFor(charString)`
 
 !!! note
-    This functionality was added in After Effects (Beta) 25.0 and is subject to change while it remains in Beta.
+    This functionality was added in After Effects 25.1
 
 #### Description
 

--- a/docs/text/fontsobject.md
+++ b/docs/text/fontsobject.md
@@ -242,7 +242,7 @@ A `SubstitutedFontReplacementMatchPolicy` enumerated value; read/write. One of:
 `app.fonts.getCTScriptForString(charString, preferredCTScript)`
 
 !!! note
-    This functionality was added in After Effects (Beta) 25.0 and is subject to change while it remains in Beta.
+    This functionality was added in After Effects 25.1
 
 #### Description
 
@@ -280,7 +280,7 @@ Array of generic objects;
 `app.fonts.getDefaultFontForCTScript(ctScript)`
 
 !!! note
-    This functionality was added in After Effects (Beta) 25.0 and is subject to change while it remains in Beta.
+    This functionality was added in After Effects 25.1
 
 #### Description
 
@@ -440,7 +440,7 @@ Boolean; One of:
 `app.fonts.setDefaultFontForCTScript(ctScript, font)`
 
 !!! note
-    This functionality was added in After Effects (Beta) 25.0 and is subject to change while it remains in Beta.
+    This functionality was added in After Effects 25.1
 
 #### Description
 


### PR DESCRIPTION
This PR updates the scripting docs for After Effects 25.4, with one new APIs and marking several other APIs as release with the appropriate version.

- Added `app.restart()` API (new in 25.4)
- Update LightLayer.lightSource
- Update several Text APIs
- Update ThreeDModelLayer